### PR TITLE
Add handling for missing methods

### DIFF
--- a/falcon_openapi/router.py
+++ b/falcon_openapi/router.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
+from falcon import routing
 from falcon.routing.compiled import CompiledRouter
 
 
@@ -53,6 +54,7 @@ class OpenApiRouter(CompiledRouter):
             for router_map in openapi_map.values():
                 Class = router_map['class']
                 method_map = router_map['method_map']
+                routing.set_default_responders(method_map)
                 self.add_route(path, method_map, Class)
 
     @staticmethod

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -25,10 +25,11 @@ class TestRouter():
 
         assert 'controllers.foo.Foo' in str(resource)
 
-        assert len(method_map) == 3
+        assert len(method_map) >= 4
         assert 'GET' in method_map
         assert 'POST' in method_map
         assert 'PUT' in method_map
+        assert 'OPTIONS' in method_map
 
         get_method = method_map['GET']
         post_method = method_map['POST']
@@ -67,8 +68,9 @@ class TestRouter():
         (resource, method_map, _, uri) = router.find('/foo')
 
         assert 'controllers.foo.Foo' in str(resource)
-        assert len(method_map) == 1
+        assert len(method_map) >= 2
         assert 'GET' in method_map
+        assert 'OPTIONS' in method_map
 
         get_method = method_map['GET']
         get_resp = TestResponse()
@@ -95,8 +97,9 @@ class TestRouter():
 
         assert 'controllers.foo.Foo' in str(resource)
 
-        assert len(method_map) == 1
+        assert len(method_map) >= 2
         assert 'GET' in method_map
+        assert 'OPTIONS' in method_map
 
         get_method = method_map['GET']
         get_resp = TestResponse()
@@ -125,8 +128,9 @@ class TestRouter():
         (resource, method_map, _, uri) = router.find('/v1/foo')
 
         assert 'controllers.foo.Foo' in str(resource)
-        assert len(method_map) == 1
+        assert len(method_map) >= 2
         assert 'GET' in method_map
+        assert 'OPTIONS' in method_map
 
         get_method = method_map['GET']
         get_resp = TestResponse()
@@ -153,8 +157,9 @@ class TestRouter():
         (resource, method_map, _, uri) = router.find('/v1/foo')
 
         assert 'controllers.foo.Foo' in str(resource)
-        assert len(method_map) == 1
+        assert len(method_map) >= 2
         assert 'GET' in method_map
+        assert 'OPTIONS' in method_map
 
         get_method = method_map['GET']
         get_resp = TestResponse()


### PR DESCRIPTION
Fixes that issue:
falcon-cors didn't work with OpenApiRouter, server responded `{"title": "Bad request", "description": "Invalid HTTP method"}` for request `curl -X OPTIONS 'http://localhost:8080/foo'`

Server example:
```python
from wsgiref import simple_server
import falcon
import yaml
from falcon_cors import CORS
from falcon_openapi import OpenApiRouter

spec = {
    'paths': {
        '/foo': {
            'get': {
                'operationId': 'controllers.foo.Foo.on_get'
            }
        }
    }
}

cors = CORS(allow_all_origins=True, allow_all_headers=True, allow_all_methods=True)
app = falcon.API(router=OpenApiRouter(raw_yaml=yaml.dump(spec)),
                 middleware=[cors.middleware])

httpd = simple_server.make_server('localhost', 8080, app)
httpd.serve_forever()
```