### PR TITLE
Fix #10: Support Falcon 2.0.0 instead of 1.4.1

### DIFF
--- a/falcon_openapi/router.py
+++ b/falcon_openapi/router.py
@@ -55,7 +55,7 @@ class OpenApiRouter(CompiledRouter):
                 Class = router_map['class']
                 method_map = router_map['method_map']
                 routing.set_default_responders(method_map)
-                self.add_route(path, method_map, Class)
+                self.add_route(path, Class)
 
     @staticmethod
     def __load_spec(file_path='', raw_json='', raw_yaml=''):
@@ -97,14 +97,14 @@ class OpenApiRouter(CompiledRouter):
 
     @staticmethod
     def __get_destination_info(definition, fallback):
-        """Gets destination module, class, method, and filename from openapi 
-        method definition. Looks for either operationId or x-falcon 
+        """Gets destination module, class, method, and filename from openapi
+        method definition. Looks for either operationId or x-falcon
         properties. If both are defined operationId takes precedence.
 
         fallback should be the http method this definition is responsible for.
         This is used to route to on_get, on_post, etc if no method defined in
         x-falcon.
-        
+
         Returns tuple (module, class, method, file_name)"""
 
         # gets the file and dir of whomever instantiated this object

--- a/test/controllers/foo.py
+++ b/test/controllers/foo.py
@@ -11,7 +11,7 @@ class Foo(object):
         resp.status = falcon.HTTP_200
         resp.json = {"method": "post"}
 
-    def do_a_put(self, req, resp):
+    def on_put(self, req, resp):
         """Handles PUT requests"""
         resp.status = falcon.HTTP_418
         resp.json = {"method": "put"}

--- a/test/openapi-spec.yaml
+++ b/test/openapi-spec.yaml
@@ -18,7 +18,7 @@ paths:
       responses:
         200:
           content:
-            application/json:    
+            application/json:
               schema:
                 $ref: "#/components/schemas/Foo"
     post:
@@ -35,7 +35,7 @@ paths:
       responses:
         200:
           content:
-            application/json:    
+            application/json:
               schema:
                 $ref: "#/components/schemas/Foo"
     put:
@@ -43,7 +43,6 @@ paths:
       x-falcon:
         module: controllers.foo
         class: Foo
-        method: do_a_put
       parameters:
         - name: limit
           in: query
@@ -53,7 +52,7 @@ paths:
       responses:
         200:
           content:
-            application/json:    
+            application/json:
               schema:
                 $ref: "#/components/schemas/Foo"
 components:


### PR DESCRIPTION
Falcon 2.0.0 came with breaking changes in the definition of
CompiledRouter.add_route(). This commit uses the new definition
instead of the old one. As a side effect naming custom handler
methods doesn't work anymore; one should stick to the on_get,
on_post etc. ones.

This obviously isn't backwards compatible with people still using Falcon 1.4.1.

See #10 